### PR TITLE
nested accordions need stoppropagation in click handler

### DIFF
--- a/jquery-accessible-accordion-aria.js
+++ b/jquery-accessible-accordion-aria.js
@@ -146,6 +146,7 @@
       $button.focus();
     }, 0);
 
+    e.stopPropagation()
     e.preventDefault();
   };
 


### PR DESCRIPTION
For a project we needed nested accordions (if that makes sense at all is another discussion ;). 
To set this up I prepared the accordions (with class `js-accordion`) as following:

    $('.js-accordion').each(function(i, e) {
      var $a = $(this)

      $a.attr('id', 'ACCORDION-' + i).accordion({
        headersSelector: '>.js-accordion__header',
        panelsSelector: '>.js-accordion__panel'
      });
    })

so each accordion gets an ID and the headers and panels selector use the child only selector (this could be change in `defaultConfig` but not sure if this makes other problems.

But the click handler needs the `stopPropagation` call to prevent closing the outer accordion as set in the PR.

Is there anything else I oversee? Not sure how to reach the inner accordion with the keyboard, guess that would be an open issue. Any feedback welcome, this is apart from this admittedly strange requirement we had a very nice solution!
